### PR TITLE
Fix 'FileNotFound' exception when a debugger is not present

### DIFF
--- a/JitMagic/JitMagic/JitMagic.cs
+++ b/JitMagic/JitMagic/JitMagic.cs
@@ -221,7 +221,7 @@ namespace JitMagic
                     listViewDebuggers.ItemActivate += (s, e) =>
                     {
                         Hide();
-                        var jitDebugger = _jitDebuggers[listViewDebuggers.SelectedItems[0].ImageIndex];
+                        var jitDebugger = listViewDebuggers.SelectedItems[0].Tag as JitDebugger;
 
                         var sec = new SECURITY_ATTRIBUTES
                         {
@@ -289,17 +289,18 @@ namespace JitMagic
             {
                 var jitDebugger = _jitDebuggers[i];
 
-                var icon = Icon.ExtractAssociatedIcon(jitDebugger.FileName);
-                listViewDebuggers.LargeImageList.Images.Add(icon.ToBitmap());
-
                 if (!File.Exists(jitDebugger.FileName))
                     continue;
+
+                var icon = Icon.ExtractAssociatedIcon(jitDebugger.FileName);
+                listViewDebuggers.LargeImageList.Images.Add(icon.ToBitmap());
 
                 if (architecture == Architecture.All || jitDebugger.Architecture == architecture || jitDebugger.Architecture == Architecture.All)
                 {
                     listViewDebuggers.Items.Add(new ListViewItem(jitDebugger.Name)
                     {
-                        ImageIndex = i
+                        ImageIndex = i,
+                        Tag = jitDebugger
                     });
                 }
             }


### PR DESCRIPTION
Fixes the following error:

```
Application: _JitMagic.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.IO.FileNotFoundException
   at System.Drawing.Icon.ExtractAssociatedIcon(System.String, Int32)
   at JitMagic.JitMagic.PopulateJitDebuggers(Architecture)
   at JitMagic.JitMagic..ctor(System.String[])
   at JitMagic.Program.Main(System.String[])
```

This occurs at startup when the default config is used, but one of the debuggers is not found